### PR TITLE
Altered RelayOutput example behavior

### DIFF
--- a/PID_v1/Examples/PID_RelayOutput/PID_RelayOutput.ino
+++ b/PID_v1/Examples/PID_RelayOutput/PID_RelayOutput.ino
@@ -24,6 +24,7 @@ double Setpoint, Input, Output;
 PID myPID(&Input, &Output, &Setpoint,2,5,1, DIRECT);
 
 int WindowSize = 5000;
+int minWindow = 500;
 unsigned long windowStartTime;
 void setup()
 {
@@ -42,16 +43,16 @@ void setup()
 void loop()
 {
   Input = analogRead(0);
-  myPID.Compute();
 
   /************************************************
    * turn the output pin on/off based on pid output
    ************************************************/
   if(millis() - windowStartTime>WindowSize)
-  { //time to shift the Relay Window
+  { //time to shift the Relay Window and recalculate
     windowStartTime += WindowSize;
+    myPID.Compute();
   }
-  if(Output < millis() - windowStartTime) digitalWrite(RelayPin,HIGH);
+  if(Output > minWindow && Output < millis() - windowStartTime) digitalWrite(RelayPin,HIGH);
   else digitalWrite(RelayPin,LOW);
 
 }


### PR DESCRIPTION
I recently made a mechanical relay based PID with time proportioning control but I noticed some behavior in the sample that was unexpected, and this pull request is an attempt to address those.

First, is that given a window size of 5000 and a PID output of say, 2000 I would expect the PID to be on for 2000 out of 5000 milliseconds.  The call to myPID.Compute(); inside the main loop changed the output each loop so out of a 5000 millisecond slice of time, the output could vary between 2000 and 0.  I am not an expert in PIDs but it seems like it would make it hard to maintain a consistent temperature when the response depended on more than just the output state.

The other change I made was to put in a floor so that the relay would be on for a minimum amount of time.  My assumption is that mechanical relays have a response time, and anything below the response time is not useful.

Finally, thank you for writing the PID library and contributing, I find it very useful and I'm glad you made it.
