### PR TITLE
Use constants instead of #define for parameters

### DIFF
--- a/PID_v1/Examples/PID_AdaptiveTunings/PID_AdaptiveTunings.ino
+++ b/PID_v1/Examples/PID_AdaptiveTunings/PID_AdaptiveTunings.ino
@@ -19,7 +19,7 @@ double aggKp=4, aggKi=0.2, aggKd=1;
 double consKp=1, consKi=0.05, consKd=0.25;
 
 //Specify the links and initial tuning parameters
-PID myPID(&Input, &Output, &Setpoint, consKp, consKi, consKd, DIRECT);
+PID myPID(&Input, &Output, &Setpoint, consKp, consKi, consKd, PID::Direct);
 
 void setup()
 {
@@ -28,7 +28,7 @@ void setup()
   Setpoint = 100;
 
   //turn the PID on
-  myPID.SetMode(AUTOMATIC);
+  myPID.SetMode(PID::Automatic);
 }
 
 void loop()

--- a/PID_v1/Examples/PID_Basic/PID_Basic.ino
+++ b/PID_v1/Examples/PID_Basic/PID_Basic.ino
@@ -9,7 +9,7 @@
 double Setpoint, Input, Output;
 
 //Specify the links and initial tuning parameters
-PID myPID(&Input, &Output, &Setpoint,2,5,1, DIRECT);
+PID myPID(&Input, &Output, &Setpoint,2,5,1, PID::Direct);
 
 void setup()
 {
@@ -18,7 +18,7 @@ void setup()
   Setpoint = 100;
 
   //turn the PID on
-  myPID.SetMode(AUTOMATIC);
+  myPID.SetMode(PID::Automatic);
 }
 
 void loop()

--- a/PID_v1/Examples/PID_RelayOutput/PID_RelayOutput.ino
+++ b/PID_v1/Examples/PID_RelayOutput/PID_RelayOutput.ino
@@ -21,7 +21,7 @@
 double Setpoint, Input, Output;
 
 //Specify the links and initial tuning parameters
-PID myPID(&Input, &Output, &Setpoint,2,5,1, DIRECT);
+PID myPID(&Input, &Output, &Setpoint,2,5,1, PID::Direct);
 
 int WindowSize = 5000;
 unsigned long windowStartTime;
@@ -36,7 +36,7 @@ void setup()
   myPID.SetOutputLimits(0, WindowSize);
 
   //turn the PID on
-  myPID.SetMode(AUTOMATIC);
+  myPID.SetMode(PID::Automatic);
 }
 
 void loop()

--- a/PID_v1/PID_v1.cpp
+++ b/PID_v1/PID_v1.cpp
@@ -91,7 +91,7 @@ void PID::SetTunings(double Kp, double Ki, double Kd)
    ki = Ki * SampleTimeInSec;
    kd = Kd / SampleTimeInSec;
  
-  if(controllerDirection ==REVERSE)
+  if(controllerDirection ==Reverse)
    {
       kp = (0 - kp);
       ki = (0 - ki);
@@ -139,13 +139,13 @@ void PID::SetOutputLimits(double Min, double Max)
 }
 
 /* SetMode(...)****************************************************************
- * Allows the controller Mode to be set to manual (0) or Automatic (non-zero)
+ * Allows the controller Mode to be set to Manual (0) or Automatic (non-zero)
  * when the transition from manual to auto occurs, the controller is
  * automatically initialized
  ******************************************************************************/ 
 void PID::SetMode(int Mode)
 {
-    bool newAuto = (Mode == AUTOMATIC);
+    bool newAuto = (Mode == Automatic);
     if(newAuto == !inAuto)
     {  /*we just went from manual to auto*/
         PID::Initialize();
@@ -166,8 +166,8 @@ void PID::Initialize()
 }
 
 /* SetControllerDirection(...)*************************************************
- * The PID will either be connected to a DIRECT acting process (+Output leads 
- * to +Input) or a REVERSE acting process(+Output leads to -Input.)  we need to
+ * The PID will either be connected to a Direct acting process (+Output leads 
+ * to +Input) or a Reverse acting process(+Output leads to -Input.)  we need to
  * know which one, because otherwise we may increase the output when we should
  * be decreasing.  This is called from the constructor.
  ******************************************************************************/
@@ -190,6 +190,6 @@ void PID::SetControllerDirection(int Direction)
 double PID::GetKp(){ return  dispKp; }
 double PID::GetKi(){ return  dispKi;}
 double PID::GetKd(){ return  dispKd;}
-int PID::GetMode(){ return  inAuto ? AUTOMATIC : MANUAL;}
+int PID::GetMode(){ return  inAuto ? Automatic : Manual;}
 int PID::GetDirection(){ return controllerDirection;}
 

--- a/PID_v1/PID_v1.h
+++ b/PID_v1/PID_v1.h
@@ -9,10 +9,10 @@ class PID
   public:
 
   //Constants used in some of the functions below
-  #define AUTOMATIC	1
-  #define MANUAL	0
-  #define DIRECT  0
-  #define REVERSE  1
+    static const int Automatic = 1;
+    static const int Manual = 0;
+    static const int Direct = 0;
+    static const int Reverse = 1;
 
   //commonly used functions **************************************************************************
     PID(double*, double*, double*,        // * constructor.  links the PID to the Input, Output, and 
@@ -35,8 +35,8 @@ class PID
     void SetTunings(double, double,       // * While most users will set the tunings once in the 
                     double);         	  //   constructor, this function gives the user the option
                                           //   of changing tunings during runtime for Adaptive control
-	void SetControllerDirection(int);	  // * Sets the Direction, or "Action" of the controller. DIRECT
-										  //   means the output will increase when error is positive. REVERSE
+	void SetControllerDirection(int);	  // * Sets the Direction, or "Action" of the controller. Direct
+										  //   means the output will increase when error is positive. Reverse
 										  //   means the opposite.  it's very unlikely that this will be needed
 										  //   once it is set in the constructor.
     void SetSampleTime(int);              // * sets the frequency, in Milliseconds, with which 

--- a/PID_v1/keywords.txt
+++ b/PID_v1/keywords.txt
@@ -28,7 +28,7 @@ GetDirection	KEYWORD2
 # Constants (LITERAL1)
 #######################################
 
-AUTOMATIC	LITERAL1
-MANUAL	LITERAL1
-DIRECT	LITERAL1
-REVERSE	LITERAL1
+Automatic	LITERAL1
+Manual	LITERAL1
+Direct	LITERAL1
+Reverse	LITERAL1


### PR DESCRIPTION
Avoids name conflicts.
