### PR TITLE
Use enums instead of defines for parameters

### DIFF
--- a/PID_v1.cpp
+++ b/PID_v1.cpp
@@ -18,7 +18,7 @@
  *    reliable defaults, so we need to have the user set them.
  ***************************************************************************/
 PID::PID(double* Input, double* Output, double* Setpoint,
-        double Kp, double Ki, double Kd, int ControllerDirection)
+        double Kp, double Ki, double Kd, direction_t ControllerDirection)
 {
 	
     myOutput = Output;
@@ -139,11 +139,11 @@ void PID::SetOutputLimits(double Min, double Max)
 }
 
 /* SetMode(...)****************************************************************
- * Allows the controller Mode to be set to manual (0) or Automatic (non-zero)
+ * Allows the controller Mode to be set to MANUAL (0) or AUTOMATIC (1)
  * when the transition from manual to auto occurs, the controller is
  * automatically initialized
  ******************************************************************************/ 
-void PID::SetMode(int Mode)
+void PID::SetMode(mode_t Mode)
 {
     bool newAuto = (Mode == AUTOMATIC);
     if(newAuto == !inAuto)
@@ -171,7 +171,7 @@ void PID::Initialize()
  * know which one, because otherwise we may increase the output when we should
  * be decreasing.  This is called from the constructor.
  ******************************************************************************/
-void PID::SetControllerDirection(int Direction)
+void PID::SetControllerDirection(direction_t Direction)
 {
    if(inAuto && Direction !=controllerDirection)
    {

--- a/PID_v1.h
+++ b/PID_v1.h
@@ -8,17 +8,16 @@ class PID
 
   public:
 
-  //Constants used in some of the functions below
-  #define AUTOMATIC	1
-  #define MANUAL	0
-  #define DIRECT  0
-  #define REVERSE  1
+  //Parameter types for some of the functions below
+    enum mode_t { AUTOMATIC = 1, MANUAL = 0 };
+    enum direction_t { DIRECT = 0, REVERSE = 1 };
 
   //commonly used functions **************************************************************************
     PID(double*, double*, double*,        // * constructor.  links the PID to the Input, Output, and 
-        double, double, double, int);     //   Setpoint.  Initial tuning parameters are also set here
+        double, double, double,           //   Setpoint.  Initial tuning parameters are also set here
+        direction_t);
 	
-    void SetMode(int Mode);               // * sets PID to either Manual (0) or Auto (non-0)
+    void SetMode(mode_t);                 // * sets PID to either MANUAL (0) or AUTOMATIC (1)
 
     bool Compute();                       // * performs the PID calculation.  it should be
                                           //   called every time loop() cycles. ON/OFF and
@@ -35,8 +34,8 @@ class PID
     void SetTunings(double, double,       // * While most users will set the tunings once in the 
                     double);         	  //   constructor, this function gives the user the option
                                           //   of changing tunings during runtime for Adaptive control
-	void SetControllerDirection(int);	  // * Sets the Direction, or "Action" of the controller. DIRECT
-										  //   means the output will increase when error is positive. REVERSE
+	void SetControllerDirection(          // * Sets the Direction, or "Action" of the controller. DIRECT
+                    direction_t);         //   means the output will increase when error is positive. REVERSE
 										  //   means the opposite.  it's very unlikely that this will be needed
 										  //   once it is set in the constructor.
     void SetSampleTime(int);              // * sets the frequency, in Milliseconds, with which 

--- a/examples/PID_AdaptiveTunings/PID_AdaptiveTunings.ino
+++ b/examples/PID_AdaptiveTunings/PID_AdaptiveTunings.ino
@@ -22,7 +22,7 @@ double aggKp=4, aggKi=0.2, aggKd=1;
 double consKp=1, consKi=0.05, consKd=0.25;
 
 //Specify the links and initial tuning parameters
-PID myPID(&Input, &Output, &Setpoint, consKp, consKi, consKd, DIRECT);
+PID myPID(&Input, &Output, &Setpoint, consKp, consKi, consKd, PID::DIRECT);
 
 void setup()
 {
@@ -31,7 +31,7 @@ void setup()
   Setpoint = 100;
 
   //turn the PID on
-  myPID.SetMode(AUTOMATIC);
+  myPID.SetMode(PID::AUTOMATIC);
 }
 
 void loop()

--- a/examples/PID_Basic/PID_Basic.ino
+++ b/examples/PID_Basic/PID_Basic.ino
@@ -13,7 +13,7 @@ double Setpoint, Input, Output;
 
 //Specify the links and initial tuning parameters
 double Kp=2, Ki=5, Kd=1;
-PID myPID(&Input, &Output, &Setpoint, Kp, Ki, Kd, DIRECT);
+PID myPID(&Input, &Output, &Setpoint, Kp, Ki, Kd, PID::DIRECT);
 
 void setup()
 {
@@ -22,7 +22,7 @@ void setup()
   Setpoint = 100;
 
   //turn the PID on
-  myPID.SetMode(AUTOMATIC);
+  myPID.SetMode(PID::AUTOMATIC);
 }
 
 void loop()

--- a/examples/PID_RelayOutput/PID_RelayOutput.ino
+++ b/examples/PID_RelayOutput/PID_RelayOutput.ino
@@ -24,7 +24,7 @@ double Setpoint, Input, Output;
 
 //Specify the links and initial tuning parameters
 double Kp=2, Ki=5, Kd=1;
-PID myPID(&Input, &Output, &Setpoint, Kp, Ki, Kd, DIRECT);
+PID myPID(&Input, &Output, &Setpoint, Kp, Ki, Kd, PID::DIRECT);
 
 int WindowSize = 5000;
 unsigned long windowStartTime;
@@ -40,7 +40,7 @@ void setup()
   myPID.SetOutputLimits(0, WindowSize);
 
   //turn the PID on
-  myPID.SetMode(AUTOMATIC);
+  myPID.SetMode(PID::AUTOMATIC);
 }
 
 void loop()


### PR DESCRIPTION
Avoids name conflicts.
