### PR TITLE
Continuous Integration using @PlatformIO and @travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: python
+python:
+    - "2.7"
+
+# Cache PlatformIO packages using Travis CI container-based infrastructure
+sudo: false
+cache:
+    directories:
+        - "~/.platformio"
+
+env:
+    - PLATFORMIO_CI_SRC=examples/PID_AdaptiveTunings/PID_AdaptiveTunings.ino
+    - PLATFORMIO_CI_SRC=examples/PID_Basic/PID_Basic.ino
+    - PLATFORMIO_CI_SRC=examples/PID_RelayOutput/PID_RelayOutput.ino
+
+install:
+    - pip install -U platformio
+
+script:
+    - platformio ci --lib=. --board=uno --board=megaatmega1280


### PR DESCRIPTION
@PlatformIO (an open source ecosystem for IoT development) in pair with @travis-ci (an open-source hosted, distributed continuous integration service) proposes to apply continuos integration for embedded projects in a few clicks.

* Official Travis CI Documentation for PlatformIO: https://docs.travis-ci.com/user/integration/platformio/
* PlatformIO documentation for Travis CI: http://docs.platformio.org/en/latest/ci/travis.html

## Quickstart
Please enable Travis.CI for this project http://docs.travis-ci.com/user/getting-started/#To-get-started-with-Travis-CI%3A (steps 1, 2, 5)

## Status Badge
You can add badge with build status to your README

**Markdown**
```
[![Build Status](https://travis-ci.org/br3ttb/Arduino-PID-Library.svg?branch=master)](https://travis-ci.org/br3ttb/Arduino-PID-Library)
```

**RST**
```
.. image:: https://travis-ci.org/br3ttb/Arduino-PID-Library.svg?branch=master
    :target: https://travis-ci.org/br3ttb/Arduino-PID-Library
```

## Examples

* Project [USB_Host_Shield_2.0](https://github.com/felis/USB_Host_Shield_2.0) and [Travis CI Build](https://travis-ci.org/felis/USB_Host_Shield_2.0)
* Project [Arduino-IRremote](https://github.com/z3t0/Arduino-IRremote) and [Travis CI Build](https://travis-ci.org/z3t0/Arduino-IRremote)
* Project [ethercard](https://github.com/jcw/ethercard) and [Travis CI Build](https://travis-ci.org/jcw/ethercard)