### PR TITLE
added integral term reset functionality

### DIFF
--- a/PID_v1.cpp
+++ b/PID_v1.cpp
@@ -98,6 +98,13 @@ void PID::SetTunings(double Kp, double Ki, double Kd)
       kd = (0 - kd);
    }
 }
+
+/* ResetI() *******************************************************************
+ * Resets the build up integral term of the PID	
+ ******************************************************************************/
+void PID::ResetI() {
+	ITerm = 0;
+}
   
 /* SetSampleTime(...) *********************************************************
  * sets the period, in Milliseconds, at which the calculation is performed	

--- a/PID_v1.h
+++ b/PID_v1.h
@@ -35,6 +35,10 @@ class PID
     void SetTunings(double, double,       // * While most users will set the tunings once in the 
                     double);         	  //   constructor, this function gives the user the option
                                           //   of changing tunings during runtime for Adaptive control
+                                          
+    void ResetI();						  // * Resets Integral term of PID: Useful especially for multicopters.
+										  // * This allows to reset this term when the multicopter descends to 
+										  // * the ground and contionues the flight again later.
 	void SetControllerDirection(int);	  // * Sets the Direction, or "Action" of the controller. DIRECT
 										  //   means the output will increase when error is positive. REVERSE
 										  //   means the opposite.  it's very unlikely that this will be needed

--- a/keywords.txt
+++ b/keywords.txt
@@ -16,6 +16,7 @@ SetMode	KEYWORD2
 Compute	KEYWORD2
 SetOutputLimits	KEYWORD2
 SetTunings	KEYWORD2
+ResetI	KEYWORD2
 SetControllerDirection	KEYWORD2
 SetSampleTime	KEYWORD2
 GetKp	KEYWORD2


### PR DESCRIPTION
I was building a quad-copter drone from scratch when I realized that resetting integral part is a crucial  step I need to take every time I come back to ground station but do not tun off the robot.
I have added this functionality to PID library and created this pull request because I believe this is a key feature of PID algorithm.