### PR TITLE
Set pin mode of RELAY_PIN in PID_RelayOutput example

### DIFF
--- a/examples/PID_RelayOutput/PID_RelayOutput.ino
+++ b/examples/PID_RelayOutput/PID_RelayOutput.ino
@@ -31,6 +31,8 @@ unsigned long windowStartTime;
 
 void setup()
 {
+  pinMode(RELAY_PIN, OUTPUT);
+
   windowStartTime = millis();
 
   //initialize the variables we're linked to


### PR DESCRIPTION
Fixes https://github.com/br3ttb/Arduino-PID-Library/issues/8