### PR TITLE
outputSum is now capped after merging with output

### DIFF
--- a/PID_v1.cpp
+++ b/PID_v1.cpp
@@ -71,9 +71,6 @@ bool PID::Compute()
       /*Add Proportional on Measurement, if P_ON_M is specified*/
       if(!pOnE) outputSum-= kp * dInput;
 
-      if(outputSum > outMax) outputSum= outMax;
-      else if(outputSum < outMin) outputSum= outMin;
-
       /*Add Proportional on Error, if P_ON_E is specified*/
 	   double output;
       if(pOnE) output = kp * error;
@@ -81,6 +78,9 @@ bool PID::Compute()
 
       /*Compute Rest of PID Output*/
       output += outputSum - kd * dInput;
+
+      if(outputSum > outMax) outputSum= outMax;
+      else if(outputSum < outMin) outputSum= outMin;
 
 	    if(output > outMax) output = outMax;
       else if(output < outMin) output = outMin;


### PR DESCRIPTION
Why is **outputSum** capped before merging into **output**?

When **outputSum** is operating at it's limit and is being capped before merging into **output**, the **output** becomes vulnerable to tiny opposing forces in the derivative and the proportional, even though the integral force is stronger than the other two combined.

Is that a desirable feature?, and why?