### PR TITLE
Merged two "ifs" into one

### DIFF
--- a/PID_v1.cpp
+++ b/PID_v1.cpp
@@ -66,21 +66,23 @@ bool PID::Compute()
       double input = *myInput;
       double error = *mySetpoint - input;
       double dInput = (input - lastInput);
+      double output;
+
+      /*Compute integral*/
       outputSum+= (ki * error);
 
-      /*Add Proportional on Measurement, if P_ON_M is specified*/
-      if(!pOnE) outputSum-= kp * dInput;
+      /*Compute proportional*/
+      if(pOnE) output = kp * error;
+      else { outputSum -= kp * dInput; output = 0; }
 
       if(outputSum > outMax) outputSum= outMax;
       else if(outputSum < outMin) outputSum= outMin;
 
-      /*Add Proportional on Error, if P_ON_E is specified*/
-	   double output;
-      if(pOnE) output = kp * error;
-      else output = 0;
+      /*Compute derivative*/
+      output -= kd * dInput;
 
-      /*Compute Rest of PID Output*/
-      output += outputSum - kd * dInput;
+      /*Merge*/
+      output += outputSum;
 
 	    if(output > outMax) output = outMax;
       else if(output < outMin) output = outMin;


### PR DESCRIPTION
Merged this two ifs:
`if(!pOnE) outputSum-= kp * dInput;`
```
if(pOnE) output = kp * error;
else output = 0;
```
into this one:
```
if(pOnE) output = kp * error;
else { outputSum -= kp * dInput; output = 0; }
```

I expect a performance improvement by the **if** reduction, or am I missing something?

I also separated the derivative computing from the ouputSum merging to add comments to indicate where each parameter is being computed.

Changed this:
```
      /*Compute Rest of PID Output*/
      output += outputSum - kd * dInput;
```
into this:
```
      /*Compute derivative*/
      output -= kd * dInput;
      /*Merge*/
      output += outputSum;
```
I believe it will compile the same, whether is separated or not. But if you don't like this part I'll remake the PR to remove this.