### PR TITLE
update Compute() so it computes on the first call

### DIFF
--- a/PID_v1.cpp
+++ b/PID_v1.cpp
@@ -57,10 +57,12 @@ PID::PID(double* Input, double* Output, double* Setpoint,
  **********************************************************************************/
 bool PID::Compute()
 {
+   static bool first = true;
+
    if(!inAuto) return false;
    unsigned long now = millis();
    unsigned long timeChange = (now - lastTime);
-   if(timeChange>=SampleTime)
+   if(first || (timeChange>=SampleTime))
    {
       /*Compute all the working error variables*/
       double input = *myInput;
@@ -89,6 +91,7 @@ bool PID::Compute()
       /*Remember some variables for next time*/
       lastInput = input;
       lastTime = now;
+      first = false;
 	    return true;
    }
    else return false;


### PR DESCRIPTION
This is a small change to update Comput() so that it produces a non-zero output on the first call. The issue I noticed was that the PID output after the first call was always zero. I guess for most setups this wouldn't be a big issue. The reason it is for me is that I'm using the PID output to set the duty cycle for a relay controlling a fridge, and the time window is 15 minutes. Therefore, every time I restarted the Arduino it would turn off the fridge for 15 minutes. I thought this might be useful to other people so I'm submitting this pull request.