### PR TITLE
modified SetSampleTime() to allow PID::Compute() synch to external timing source

### DIFF
--- a/PID_v1.cpp
+++ b/PID_v1.cpp
@@ -130,6 +130,8 @@ void PID::SetTunings(double Kp, double Ki, double Kd){
 
 /* SetSampleTime(...) *********************************************************
  * sets the period, in Milliseconds, at which the calculation is performed
+ * 15 May 2021 gfp - a value of zero will force Compute() to generate a new output every time it is called
+ * but avoids the 'divide-by-zero' problem
  ******************************************************************************/
 void PID::SetSampleTime(int NewSampleTime)
 {
@@ -139,7 +141,11 @@ void PID::SetSampleTime(int NewSampleTime)
                       / (double)SampleTime;
       ki *= ratio;
       kd /= ratio;
-      SampleTime = (unsigned long)NewSampleTime;
+      //SampleTime = (unsigned long)NewSampleTime;
+   }
+   else if (NewSampleTime == 0)
+   {
+     SampleTime = (unsigned long)NewSampleTime;
    }
 }
 


### PR DESCRIPTION
I modified SetSampleTime() to set the internal SampleTime variable to zero for an input argument of zero, without modifying ki or kd.  This forces Compute() to generate a new output value each time it is called, and allows the PID engine to be synchronized with an external timing source.

This modification does not change the normal behavior in any way, but allows a knowledgeable user to synchronize the PID engine to an external timing source.