### PR TITLE
Backcalculate integral sum into feasible range 

### DIFF
--- a/PID_v1.cpp
+++ b/PID_v1.cpp
@@ -82,9 +82,15 @@ bool PID::Compute()
       /*Compute Rest of PID Output*/
       output += outputSum - kd * dInput;
 
-	    if(output > outMax) output = outMax;
-      else if(output < outMin) output = outMin;
-	    *myOutput = output;
+      if(output > outMax){
+          outputSum -= output - outMax; // backcalculate integral to feasability
+          output = outMax;
+      }
+      else if(output < outMin) {
+          outputSum += outMin - output; // backcalculate integral to feasability
+          output = outMin;
+      }
+      *myOutput = output;
 
       /*Remember some variables for next time*/
       lastInput = input;


### PR DESCRIPTION
Remove excess integral windup per 
Astrom, K.J. and Rundqwist, L. (1989). "Integrator windup and how to avoid it" (PDF). Proc. 1989 Am. Control Confi.: 1693–1698. 
through using code by Will posted in Brett Beauregard's forum at 
http://brettbeauregard.com/blog/2011/04/improving-the-beginner%e2%80%99s-pid-reset-windup/#comment-18721