### PR TITLE
Expose integral to enable user-space hacking

### DIFF
--- a/PID_v1.h
+++ b/PID_v1.h
@@ -52,6 +52,8 @@ class PID
                                           //   the PID calculation is performed.  default is 100
 										  
 										  
+	void Initialize();		  // * bumpless update of internal variables.
+	double outputSum;		  // * internal integrator state for understanding and user-space control
 										  
   //Display functions ****************************************************************
 	double GetKp();						  // These functions query the pid for interal values.
@@ -61,7 +63,6 @@ class PID
 	int GetDirection();					  //
 
   private:
-	void Initialize();
 	
 	double dispKp;				// * we'll hold on to the tuning parameters in user-entered 
 	double dispKi;				//   format for display purposes
@@ -80,7 +81,7 @@ class PID
                                   //   what these values are.  with pointers we'll just know.
 			  
 	unsigned long lastTime;
-	double outputSum, lastInput;
+	double lastInput;
 
 	unsigned long SampleTime;
 	double outMin, outMax;


### PR DESCRIPTION
Based on the discussion in https://github.com/br3ttb/Arduino-PID-Library/pull/132#issuecomment-1452803503
I realized that a low impact way of handling the issues would be to just move some features out of the black box.

Moving the  `PID::Initialize()` function out to public makes the  `SetMode(MANUAL);Output=value;SetMode(MANUAL);` trick easier to discuss and handle.

Moving the `PID::outputSum` variable from private to public makes it possible to examine (or hack on) the internal integrator state.

Since these functions already exist, it should be a no-cost change and enables easy understanding of what the algorithm does and easy adaptation to special uses.

A live example:

https://wokwi.com/projects/358190033668210689

<img width="606" alt="image" src="https://user-images.githubusercontent.com/2236516/222754088-f83ccc52-2a99-424c-8b17-6803788ce39f.png">


This minimal-impact change would obviate https://github.com/br3ttb/Arduino-PID-Library/pull/132