### PR TITLE
Const correctness for getX functions

### DIFF
--- a/PID_v1.cpp
+++ b/PID_v1.cpp
@@ -216,9 +216,8 @@ void PID::SetControllerDirection(int Direction)
  * functions query the internal state of the PID.  they're here for display
  * purposes.  this are the functions the PID Front-end uses for example
  ******************************************************************************/
-double PID::GetKp(){ return  dispKp; }
-double PID::GetKi(){ return  dispKi;}
-double PID::GetKd(){ return  dispKd;}
-int PID::GetMode(){ return  inAuto ? AUTOMATIC : MANUAL;}
-int PID::GetDirection(){ return controllerDirection;}
-
+double PID::GetKp() const { return dispKp; }
+double PID::GetKi() const { return dispKi; }
+double PID::GetKd() const { return dispKd; }
+int PID::GetMode() const { return inAuto ? AUTOMATIC : MANUAL; }
+int PID::GetDirection() const { return controllerDirection; }

--- a/PID_v1.h
+++ b/PID_v1.h
@@ -54,11 +54,11 @@ class PID
 										  
 										  
   //Display functions ****************************************************************
-	double GetKp();						  // These functions query the pid for interal values.
-	double GetKi();						  //  they were created mainly for the pid front-end,
-	double GetKd();						  // where it's important to know what is actually 
-	int GetMode();						  //  inside the PID.
-	int GetDirection();					  //
+	double GetKp() const;		// These functions query the pid for interal values.
+	double GetKi() const;		// they were created mainly for the pid front-end,
+	double GetKd() const;		// where it's important to know what is actually 
+	int GetMode() const;		// inside the PID.
+	int GetDirection() const;	//
 
   private:
 	void Initialize();

--- a/README.txt
+++ b/README.txt
@@ -9,3 +9,5 @@
    http://brettbeauregard.com/blog/2011/04/improving-the-beginners-pid-introduction/
 
  - For function documentation see:  http://playground.arduino.cc/Code/PIDLibrary (Click "Libraries" on the left panel. The link to the documentation is listed as "PIDLibrary - Provides basic feedback control".)
+
+ - Very minor edits made to add const correctness


### PR DESCRIPTION
Allows use of the functions in a const contex, e.g. via const reference etc.